### PR TITLE
Video poster for PayBrackets card

### DIFF
--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -26,6 +26,7 @@ interface Props {
   link?: string;
   image?: string;
   video?: string;
+  poster?: string;
   links?: readonly {
     icon: React.ReactNode;
     type: string;
@@ -43,6 +44,7 @@ export function ProjectCard({
   link,
   image,
   video,
+  poster,
   links,
   className,
 }: Props) {
@@ -87,6 +89,7 @@ export function ProjectCard({
             <video
               ref={videoRef}
               src={video}
+              poster={poster}
               loop
               muted
               playsInline

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -295,6 +295,7 @@ export const DATA = {
       ],
       image: "",
       video: "https://video.gumlet.io/6745e593080b60408ca085f7/6a460104e4e7cc890ee9e003/download.mp4",
+      poster: "https://video.gumlet.io/6745e593080b60408ca085f7/6a460104e4e7cc890ee9e003/thumbnail-1-0.png?v=1782972766299",
     },
     {
       title: "Next.js Learning",


### PR DESCRIPTION
## Summary
- Shows the Gumlet thumbnail (calculator results frame) before the PayBrackets card video plays, instead of the empty first frame
- Adds an optional poster prop to ProjectCard


Made with [Cursor](https://cursor.com)