### PR TITLE
Lengthen meta descriptions site-wide for better search CTR

### DIFF
--- a/content/black-screen-debian.mdx
+++ b/content/black-screen-debian.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'How I Fixed the Black Screen Issue in KDE Plasma'
 publishedAt: "2025-08-17"
-summary: 'A simple guide explaining how to fix the black screen issue in KDE Plasma'
+summary: 'How I fixed the black screen issue in KDE Plasma — what causes it after login, the exact commands that solved it, and how to stop it coming back.'
 tags: ['KDE', 'Linux', 'Debian', 'Plasma']
 ---
 

--- a/content/cursor-free.mdx
+++ b/content/cursor-free.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'How to use Cursor for Free'
 publishedAt: "2025-04-09"
-summary: 'A comprehensive guide explaining how to use Cursor for free'
+summary: 'A practical guide to using Cursor for free — what the free tier gives you, where the limits are, and how to get the most out of the AI editor without paying.'
 tags: ['Cursor', 'AI', 'Web Development', 'JavaScript']
 ---
 

--- a/content/hello-world.mdx
+++ b/content/hello-world.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Is Computer Science Still Worth It?"
 publishedAt: "2024-12-07"
-summary: "The real scoop on tech careers from a friend who's been there"
+summary: "Is a computer science degree still worth it? The real scoop on tech careers from a friend who's been there — no sugarcoating, just how the industry actually works."
 tags: ["tech", "computerscience", "coding"]
 ---
 

--- a/content/ubuntu-is-bloated.mdx
+++ b/content/ubuntu-is-bloated.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Is Ubuntu Completely bloated?"
 publishedAt: "2024-12-16"
-summary: "The reality of Ubuntu Distro now"
+summary: "Is Ubuntu actually bloated? A look at what ships with the distro today, how it affects performance, and whether you should switch to something leaner."
 tags: ["tech", "computerscience", "coding","ubuntu","Linux"]
 ---
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,7 +6,7 @@ import { BreadcrumbJsonLd } from "@/components/breadcrumb-jsonld";
 
 export const metadata = {
   title: "Blog",
-  description: "Technical articles about web development, React, Next.js, and software engineering by Prasenjit Nayak.",
+  description: "Blog by Prasenjit Nayak — honest takes on web development, Next.js, AI tools like Cursor and Claude, Linux, and what it's like shipping as a freelance dev.",
   metadataBase: new URL(DATA.url),
   alternates: {
     canonical: `${DATA.url}/blog`,

--- a/src/app/gadgets/page.tsx
+++ b/src/app/gadgets/page.tsx
@@ -12,20 +12,20 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Gadgets",
-  description: "My tech setup - PC components, peripherals, and productivity tools I use daily as a developer.",
+  description: "The gear behind my work — PC build, peripherals, and the software I use daily as a freelance full stack developer, with honest picks and recommendations.",
   alternates: {
     canonical: `${DATA.url}/gadgets`,
   },
   openGraph: {
     title: "Gadgets & Setup | Prasenjit Nayak",
-    description: "PC components, peripherals, and productivity tools I use daily as a developer.",
+    description: "The gear behind my work — PC build, peripherals, and the software I use daily as a freelance full stack developer, with honest picks and recommendations.",
     url: `${DATA.url}/gadgets`,
     images: [{ url: `${DATA.url}/api/og?title=Gadgets%20%26%20Setup&type=page`, width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Gadgets & Setup | Prasenjit Nayak",
-    description: "PC components, peripherals, and productivity tools I use daily as a developer.",
+    description: "The gear behind my work — PC build, peripherals, and the software I use daily as a freelance full stack developer, with honest picks and recommendations.",
     images: [`${DATA.url}/api/og?title=Gadgets%20%26%20Setup&type=page`],
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,7 +55,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Prasenjit Nayak | Full Stack Developer',
-    description: 'Full Stack Developer specializing in React, Next.js, TypeScript and Node.js',
+    description: 'Full Stack Developer specializing in React, Next.js, TypeScript and Node.js. Check out my portfolio, projects and blog posts.',
     images: [`${DATA.url}/og.png`],
     creator: '@prasenx',
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,12 +45,16 @@ const SOCIAL_HOVER_COLORS: Record<string, string> = {
   Steam: "hover:text-[#00adee]",
   Discord: "hover:text-[#5865f2]",
 };
+// Plain-text description — DATA.summary is markdown and leaks syntax into meta tags
+const HOME_DESCRIPTION =
+  "Freelance full stack developer from Bhubaneswar, India. I build with Next.js, TypeScript and React — Outbuilt, Jungle Trail and more — open to DevRel work.";
+
 export const metadata: Metadata = {
   title: DATA.name,
-  description: DATA.summary,
+  description: HOME_DESCRIPTION,
   openGraph: {
     title: DATA.name,
-    description: DATA.summary,
+    description: HOME_DESCRIPTION,
     url: DATA.url,
     siteName: DATA.name,
     images: [
@@ -67,7 +71,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: DATA.name,
-    description: DATA.summary,
+    description: HOME_DESCRIPTION,
     creator: '@prasenx',
     images: ['https://prasen.dev/portfolio.png'],
   },

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -7,20 +7,20 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Projects",
-  description: "Web applications and open source projects built with React, Next.js, TypeScript, and Node.js by Prasenjit Nayak.",
+  description: "Projects by Prasenjit Nayak — Outbuilt, a pay-to-rank leaderboard making revenue; Jungle Trail, a procedural Three.js jungle; Wallpaperz, CleanType and more.",
   alternates: {
     canonical: `${DATA.url}/projects`,
   },
   openGraph: {
     title: "Projects | Prasenjit Nayak",
-    description: "Web applications and open source projects built with React, Next.js, TypeScript, and Node.js.",
+    description: "Projects by Prasenjit Nayak — Outbuilt, a pay-to-rank leaderboard making revenue; Jungle Trail, a procedural Three.js jungle; Wallpaperz, CleanType and more.",
     url: `${DATA.url}/projects`,
     images: [{ url: `${DATA.url}/api/og?title=Projects&type=page`, width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Projects | Prasenjit Nayak",
-    description: "Web applications and open source projects built with React, Next.js, TypeScript, and Node.js.",
+    description: "Projects by Prasenjit Nayak — Outbuilt, a pay-to-rank leaderboard making revenue; Jungle Trail, a procedural Three.js jungle; Wallpaperz, CleanType and more.",
     images: [`${DATA.url}/api/og?title=Projects&type=page`],
   },
 };

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -9,20 +9,20 @@ export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Videos",
-  description: "Watch my latest videos about software development, coding tutorials, and technology by Prasenjit Nayak.",
+  description: "Videos by Prasenjit Nayak — coding tutorials, dev workflows, and honest tech takes from a freelance full stack developer building with Next.js and React.",
   alternates: {
     canonical: `${DATA.url}/videos`,
   },
   openGraph: {
     title: "Videos | Prasenjit Nayak",
-    description: "Software development videos, coding tutorials, and technology content.",
+    description: "Videos by Prasenjit Nayak — coding tutorials, dev workflows, and honest tech takes from a freelance full stack developer building with Next.js and React.",
     url: `${DATA.url}/videos`,
     images: [{ url: `${DATA.url}/api/og?title=Videos&type=page`, width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Videos | Prasenjit Nayak",
-    description: "Software development videos, coding tutorials, and technology content.",
+    description: "Videos by Prasenjit Nayak — coding tutorials, dev workflows, and honest tech takes from a freelance full stack developer building with Next.js and React.",
     images: [`${DATA.url}/api/og?title=Videos&type=page`],
   },
 };


### PR DESCRIPTION
## Summary
- Bing Webmaster Tools flagged meta descriptions as too short (site gets 1.1K impressions but only 3 clicks). Rewrote all page descriptions to 120-160 characters — specific, front-loaded, in my voice.
- Fixed the homepage leaking raw markdown (`**bold**`, `[links](urls)`) into its meta/OG/Twitter descriptions — it was using `DATA.summary` directly; now uses a clean plain-text constant.
- Updated OG/Twitter descriptions on projects, videos, gadgets, and root layout to stay consistent with the new descriptions.
- Lengthened 4 genuinely short blog frontmatter summaries (32-73 chars → 145-157); left good summaries untouched. No post content changed.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] After deploy, view source on / and /blog/cursor-free and confirm `<meta name="description">` shows clean plain text

Made with [Cursor](https://cursor.com)