### PR TITLE
Add Night Street, temporarily remove Outbuilt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,6 +16,7 @@ Prasenjit Nayak is a Full Stack Developer from Odisha, India, specializing in Re
 
 ## Key Projects
 
+- [Night Street](https://night-street.vercel.app): A photorealistic procedural city street at golden hour, walkable in the browser with zero external assets. Featured by the official Claude account on X.
 - [Outbuilt](https://outbuilt.lol): A pay-to-rank public leaderboard — no logins, no algorithms, your rank is what you paid for.
 - [PayBrackets](https://paybrackets.com): A free US take-home pay calculator for the 2026 tax year covering all 50 states and D.C., with federal and state tax breakdowns and hourly to salary conversion.
 - [Next.js Learning Platform](https://learn.prasen.dev): A free, open-source interactive learning platform for mastering Next.js with 17 structured chapters.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -295,10 +295,10 @@ export default function Page() {
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {DATA.projects
                   .filter((project) => 
-                    ["Jungle Trail", "Outbuilt", "PayBrackets"].includes(project.title)
+                    ["Jungle Trail", "Night Street", "PayBrackets"].includes(project.title)
                   )
                   .sort((a, b) => {
-                    const order = ["Jungle Trail", "Outbuilt", "PayBrackets"];
+                    const order = ["Jungle Trail", "Night Street", "PayBrackets"];
                     return order.indexOf(a.title) - order.indexOf(b.title);
                   })
                   .map((project) => (

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -254,31 +254,6 @@ export const DATA = {
   ],
   projects: [
     {
-      title: "Outbuilt",
-      href: "https://outbuilt.lol",
-      dates: "August 2026",
-      active: true,
-      description:
-        "A pay-to-rank public leaderboard. No logins, no algorithms — your rank is exactly what you paid for, and anyone can outbid you. Already generating revenue.",
-      technologies: [
-        "Next.js",
-        "React 19",
-        "TypeScript",
-        "Supabase",
-        "Dodo Payments",
-        "Tailwind CSS v4",
-      ],
-      links: [
-        {
-          type: "Website",
-          href: "https://outbuilt.lol",
-          icon: <Icons.globe className="size-3" />,
-        },
-      ],
-      image: "",
-      video: "",
-    },
-    {
       title: "Jungle Trail",
       href: "https://starknightt.github.io/jungle-trail/",
       dates: "August 2026",
@@ -306,6 +281,36 @@ export const DATA = {
       image: "",
       video: "https://video.gumlet.io/6745e593080b60408ca085f7/6a7223daec8c132ca29227c6/download.mp4",
       poster: "https://video.gumlet.io/6745e593080b60408ca085f7/6a7223daec8c132ca29227c6/thumbnail-1-0.png?v=1785865438030",
+    },
+    {
+      title: "Night Street",
+      href: "https://night-street.vercel.app/",
+      dates: "August 2026",
+      active: true,
+      description:
+        "A photorealistic city street at golden hour you can walk through in the browser. Zero external assets — every texture, mesh, and sound is generated in code. Featured by the official Claude account on X.",
+      technologies: [
+        "Three.js",
+        "React Three Fiber",
+        "TypeScript",
+        "GLSL Shaders",
+        "WebAudio API",
+        "Procedural Generation",
+      ],
+      links: [
+        {
+          type: "Website",
+          href: "https://night-street.vercel.app/",
+          icon: <Icons.globe className="size-3" />,
+        },
+        {
+          type: "Source",
+          href: "https://github.com/StarKnightt/night-street",
+          icon: <Icons.github className="size-3" />,
+        },
+      ],
+      image: "",
+      video: "",
     },
     {
       title: "PayBrackets",


### PR DESCRIPTION
## Summary
- Add Night Street (night-street.vercel.app) — photorealistic procedural city street, zero external assets, featured by the official Claude account on X — to projects, homepage featured grid, and llms.txt
- Temporarily remove Outbuilt from resume.tsx until its demo video is ready (llms.txt mention kept; it's coming back)
- Featured grid is now Jungle Trail / Night Street / PayBrackets

## Test plan
- [x] npx tsc --noEmit passes

Made with [Cursor](https://cursor.com)