### PR TITLE
Add Gumlet video and poster to Night Street project card

### DIFF
--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -310,7 +310,8 @@ export const DATA = {
         },
       ],
       image: "",
-      video: "",
+      video: "https://video.gumlet.io/6745e593080b60408ca085f7/6a8eedb10784f723ea19e7df/download.mp4",
+      poster: "https://video.gumlet.io/6745e593080b60408ca085f7/6a8eedb10784f723ea19e7df/thumbnail-1-0.png?v=1787752082926",
     },
     {
       title: "PayBrackets",


### PR DESCRIPTION
## Summary
- Wire in the freshly uploaded Gumlet video and thumbnail for the Night Street project entry, matching the Jungle Trail pattern (video + poster fields) so the card hover-plays the video with the thumbnail as poster.

## Test plan
- [x] `npx tsc --noEmit` passes

Made with [Cursor](https://cursor.com)