### PR TITLE
Add "On this page" table of contents to blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Suspense } from "react";
 import { BlogInteractions } from "@/components/blog-interactions";
 import { BlogArticle } from "@/components/blog-article";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-jsonld";
+import { TableOfContents } from "@/components/table-of-contents";
 
 export async function generateStaticParams() {
   const posts = await getBlogPosts();
@@ -108,7 +109,10 @@ export default async function Blog({
           </p>
         </Suspense>
       </div>
-      <BlogArticle html={post.source} />
+      <div className="relative">
+        <BlogArticle html={post.source} />
+        {post.toc.length >= 2 && <TableOfContents headings={post.toc} />}
+      </div>
       <BlogInteractions slug={params.slug} />
     </section>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -298,6 +298,11 @@ code[data-line-numbers-max-digits="3"] > [data-line]::before {
   word-break: break-word;
 }
 
+.prose h2,
+.prose h3 {
+  scroll-margin-top: 6rem;
+}
+
 .prose pre {
   max-width: 100%;
 }
@@ -318,8 +323,11 @@ code[data-line-numbers-max-digits="3"] > [data-line]::before {
 
 html,
 body {
-  overflow-x: hidden;
   scroll-behavior: smooth;
+}
+
+html {
+  overflow-x: hidden;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { TocEntry } from "@/data/blog";
+
+export function TableOfContents({ headings }: { headings: TocEntry[] }) {
+  const [activeId, setActiveId] = useState<string | null>(
+    headings[0]?.id ?? null
+  );
+
+  useEffect(() => {
+    const elements = headings
+      .map((h) => document.getElementById(h.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const visibility = new Map<string, boolean>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) =>
+          visibility.set(entry.target.id, entry.isIntersecting)
+        );
+        const firstVisible = elements.find((el) => visibility.get(el.id));
+        if (firstVisible) {
+          setActiveId(firstVisible.id);
+          return;
+        }
+        const above = elements.filter(
+          (el) => el.getBoundingClientRect().top < 100
+        );
+        if (above.length > 0) {
+          setActiveId(above[above.length - 1].id);
+        }
+      },
+      { rootMargin: "-96px 0px -60% 0px" }
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  const handleClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    id: string
+  ) => {
+    e.preventDefault();
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    history.replaceState(null, "", `#${id}`);
+    setActiveId(id);
+  };
+
+  return (
+    <aside className="hidden xl:block absolute right-0 top-0 h-full w-40">
+      <nav
+        aria-label="Table of contents"
+        className="sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto"
+      >
+        <p className="text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground/60">
+          On this page
+        </p>
+        <ul className="mt-3 space-y-2 border-l border-border/50 pl-3">
+          {headings.map((heading) => (
+            <li key={heading.id} className={heading.level === 3 ? "pl-3" : undefined}>
+              <a
+                href={`#${heading.id}`}
+                onClick={(e) => handleClick(e, heading.id)}
+                className={cn(
+                  "block text-[13px] leading-snug transition-colors",
+                  activeId === heading.id
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -15,6 +15,46 @@ type Metadata = {
   tags?: string[];
 };
 
+export type TocEntry = {
+  id: string;
+  text: string;
+  level: 2 | 3;
+};
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-");
+}
+
+function getNodeText(node: any): string {
+  if (node.type === "text") return node.value;
+  return (node.children ?? []).map(getNodeText).join("");
+}
+
+function rehypeHeadingIds(toc: TocEntry[]) {
+  return () => (tree: any) => {
+    const counts = new Map<string, number>();
+    const visit = (node: any) => {
+      if (node.tagName === "h2" || node.tagName === "h3") {
+        const text = getNodeText(node).trim();
+        if (text) {
+          const base = slugify(text) || "section";
+          const count = counts.get(base) ?? 0;
+          counts.set(base, count + 1);
+          const id = count === 0 ? base : `${base}-${count}`;
+          node.properties = { ...node.properties, id };
+          toc.push({ id, text, level: node.tagName === "h2" ? 2 : 3 });
+        }
+      }
+      (node.children ?? []).forEach(visit);
+    };
+    visit(tree);
+  };
+}
+
 function calculateReadingTime(content: string): string {
   const words = content.trim().split(/\s+/).length;
   const minutes = Math.ceil(words / 200);
@@ -26,9 +66,11 @@ function getMDXFiles(dir: string) {
 }
 
 export async function markdownToHTML(markdown: string) {
+  const toc: TocEntry[] = [];
   const p = await unified()
     .use(remarkParse)
     .use(remarkRehype)
+    .use(rehypeHeadingIds(toc))
     .use(rehypePrettyCode, {
       // https://rehype-pretty.pages.dev/#usage
       theme: {
@@ -40,17 +82,18 @@ export async function markdownToHTML(markdown: string) {
     .use(rehypeStringify)
     .process(markdown);
 
-  return p.toString();
+  return { html: p.toString(), toc };
 }
 
 export async function getPost(slug: string) {
   const filePath = path.join("content", `${slug}.mdx`);
   let source = fs.readFileSync(filePath, "utf-8");
   const { content: rawContent, data: metadata } = matter(source);
-  const content = await markdownToHTML(rawContent);
+  const { html: content, toc } = await markdownToHTML(rawContent);
   const readingTime = calculateReadingTime(rawContent);
   return {
     source: content,
+    toc,
     metadata: { ...metadata, readingTime } as Metadata & { readingTime: string },
     slug,
   };


### PR DESCRIPTION
## Summary
- Adds slugified ids to h2/h3 headings via a small custom rehype plugin in the existing unified pipeline (no new dependencies), which also extracts the TOC server-side in `getPost`
- New `TableOfContents` client component: sticky scroll-spy sidebar (IntersectionObserver) in the free right margin beside the article on xl+ screens, hidden below xl and when a post has fewer than 2 headings
- Moves `overflow-x: hidden` from `body` to `html` so `position: sticky` works (body as a non-scrolling scroll container was silently breaking it)
- Adds `scroll-margin-top` to prose headings so anchored sections land below the navbar

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified heading ids and matching TOC anchors on /blog/ai-harness and /blog/what-is-mcp (incl. nested h3s)
- [x] Verified in browser at 1440px: no overlap with article, sticky engages, scroll-spy tracks sections, click smooth-scrolls with correct offset, TOC stops at article end
- [x] No horizontal overflow regression on homepage

Made with [Cursor](https://cursor.com)