### PR TITLE
Re-add Outbuilt project with demo video

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -295,10 +295,10 @@ export default function Page() {
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {DATA.projects
                   .filter((project) => 
-                    ["Jungle Trail", "Night Street", "PayBrackets"].includes(project.title)
+                    ["Outbuilt", "Jungle Trail", "Night Street"].includes(project.title)
                   )
                   .sort((a, b) => {
-                    const order = ["Jungle Trail", "Night Street", "PayBrackets"];
+                    const order = ["Outbuilt", "Jungle Trail", "Night Street"];
                     return order.indexOf(a.title) - order.indexOf(b.title);
                   })
                   .map((project) => (

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -254,6 +254,32 @@ export const DATA = {
   ],
   projects: [
     {
+      title: "Outbuilt",
+      href: "https://outbuilt.lol",
+      dates: "August 2026",
+      active: true,
+      description:
+        "A pay-to-rank public leaderboard. No logins, no algorithms. Your rank is exactly what you paid for, and anyone can outbid you. Already generating revenue.",
+      technologies: [
+        "Next.js",
+        "React 19",
+        "TypeScript",
+        "Supabase",
+        "Dodo Payments",
+        "Tailwind CSS v4",
+      ],
+      links: [
+        {
+          type: "Website",
+          href: "https://outbuilt.lol",
+          icon: <Icons.globe className="size-3" />,
+        },
+      ],
+      image: "",
+      video: "https://video.gumlet.io/6745e593080b60408ca085f7/6a8ef3e50784f723ea1a0908/download.mp4",
+      poster: "https://video.gumlet.io/6745e593080b60408ca085f7/6a8ef3e50784f723ea1a0908/thumbnail-1-0.png?v=1787753505658",
+    },
+    {
       title: "Jungle Trail",
       href: "https://starknightt.github.io/jungle-trail/",
       dates: "August 2026",


### PR DESCRIPTION
## Summary
- Re-adds the Outbuilt entry to the top of the projects list (removed in #128 while waiting on the demo video), now with its Gumlet demo video and poster
- Homepage featured grid is now Outbuilt, Jungle Trail, Night Street (PayBrackets drops out of featured but stays in the full projects list)

## Test plan
- [x] `npx tsc --noEmit` passes

Made with [Cursor](https://cursor.com)